### PR TITLE
Add Suricata and Managed rules support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,11 +41,12 @@ jobs:
             terraform --version
             #
             # Install terraform-docs
-            sudo apt-add-repository "deb [arch=amd64] https://apt.releases.hashicorp.com $(lsb_release -cs) main"
-            curl -Lo ./terraform-docs https://github.com/terraform-docs/terraform-docs/releases/download/v0.12.1/terraform-docs-v0.12.1-$(uname | tr '[:upper:]' '[:lower:]')-amd64
-            chmod +x ./terraform-docs
-            sudo mv ./terraform-docs /usr/local/bin/terraform-docs
-
+            #sudo apt-add-repository "deb [arch=amd64] https://apt.releases.hashicorp.com $(lsb_release -cs) main"
+            curl -Lo terraform-docs.tar.gz https://github.com/terraform-docs/terraform-docs/releases/download/v0.16.0/terraform-docs-v0.16.0-linux-amd64.tar.gz
+            tar xfz terraform-docs.tar.gz
+            chmod +x terraform-docs
+            sudo mv terraform-docs /usr/local/bin/
+            #
       - run:
           name: test-terraform-format-and-docs
           command: make pre-commit
@@ -77,7 +78,127 @@ jobs:
 
       - run:
           name: test-terraform-linting
-          command: make tflint-deep
+          command: make tflint
+
+      - slack/notify:
+          event: fail
+          mentions: '@leverage-support'
+          custom: |
+            {
+              "blocks": [
+                {
+                  "type": "header",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "Failed Pipeline! :rotating_light::fire::bash-fire::bangbang::video-games-doom-mad::stopp:",
+                    "emoji": true
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": ":negative_squared_cross_mark: *Project*: $CIRCLE_PROJECT_REPONAME \n :negative_squared_cross_mark: *User*: $CIRCLE_USERNAME \n :negative_squared_cross_mark: *Job*: $CIRCLE_JOB in *repo* $CIRCLE_PROJECT_REPONAME \n :negative_squared_cross_mark: *Branch:* $CIRCLE_BRANCH \n :negative_squared_cross_mark: *PR:* $CIRCLE_PULL_REQUEST \n :negative_squared_cross_mark: *Last Commit:* $CIRCLE_SHA1"
+                  },
+                  "accessory": {
+                    "type": "button",
+                    "text": {
+                      "type": "plain_text",
+                      "text": ":arrow_forward: View Job in CircleCi",
+                      "emoji": true
+                    },
+                    "value": "click_me_123",
+                    "url": "$CIRCLE_BUILD_URL",
+                    "action_id": "button-action"
+                  }
+                }
+              ]
+            }
+          channel: 'tools-ci'
+      - slack/notify:
+          event: pass
+          custom: |
+            {
+              "blocks": [
+                {
+                  "type": "header",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "Successful Pipeline! :checkered_flag: :video-games-star: :video-games-mario-luigi-dance: :tada: :binbash::bb-leverage: :heart: :open-source:",
+                    "emoji": true
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": ":heavy_check_mark: *Project*: $CIRCLE_PROJECT_REPONAME \n :heavy_check_mark: *User*: $CIRCLE_USERNAME \n :heavy_check_mark: *Job*: $CIRCLE_JOB in *repo* $CIRCLE_PROJECT_REPONAME \n :heavy_check_mark: *Branch:* $CIRCLE_BRANCH \n :heavy_check_mark: *PR:* $CIRCLE_PULL_REQUEST \n :heavy_check_mark: *Last Commit:* $CIRCLE_SHA1"
+                  },
+                  "accessory": {
+                    "type": "button",
+                    "text": {
+                      "type": "plain_text",
+                      "text": ":arrow_forward: View Job in CircleCi",
+                      "emoji": true
+                    },
+                    "value": "click_me_123",
+                    "url": "$CIRCLE_BUILD_URL",
+                    "action_id": "button-action"
+                  }
+                }
+              ]
+            }
+          channel: 'tools-ci'
+
+  #
+  # Tests E2E
+  #
+  test-e2e-terratests:
+    machine:
+      image: ubuntu-2004:202107-02 # Ubuntu 20.04, Docker v20.10.7, Docker Compose v1.29.2,
+      docker_layer_caching: false
+
+    steps:
+      - checkout
+
+      - run:
+          name: Context Info Cmds
+          command: pwd && ls -ltra && git branch
+
+      - run:
+          name: Initialize Repo Makefiles
+          command: |
+            make init-makefiles
+            git update-index --assume-unchanged "Makefile"
+
+      - run:
+          name: Install awscli
+          command: sudo -H pip3 install awscli
+
+      - run:
+          name: Configure awscli
+          command: |
+            # AWS credentials dir
+            mkdir --parents /home/circleci/.aws/bb
+            sudo chown -R $USER:$USER /home/circleci/.aws
+
+            # AWS defautl awscli profile
+            aws configure set aws_access_key_id $AWS_ACCESS_KEY_ID
+            aws configure set aws_secret_access_key $AWS_SECRET_ACCESS_KEY
+            aws configure set region us-east-1
+            aws configure set output json
+
+            # AWS dev awscli profile
+            aws configure set role_arn arn:aws:iam::$AWS_ACCOUNT_ID_DEV:role/DeployMaster --profile $AWS_PROFILE_NAME
+            aws configure set source_profile default --profile $AWS_PROFILE_NAME
+
+            # moving credentials to specific project folder
+            cp /home/circleci/.aws/credentials /home/circleci/.aws/bb/credentials
+            cp /home/circleci/.aws/config /home/circleci/.aws/bb/config
+
+      - run:
+          name: Test AWS permissions
+          command: aws ec2 describe-instances --region us-east-1 --profile $AWS_PROFILE_NAME
 
       - run:
           name: test-terratests-dep-init
@@ -296,7 +417,7 @@ workflows:
             branches:
              only: # only branches matching the below regex filters will run
                - master
-      - sumologic/workflow-collector:
-          context: binbashar-org-global-context
+      # - sumologic/workflow-collector:
+      #     context: binbashar-org-global-context
           requires:
             - release-version-with-changelog

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -409,8 +409,8 @@ workflows:
           context: binbashar-org-global-context
           filters:
             branches:
-              ignore: # only branches matching the below regex filters will run
-                - master
+             ignore: # only branches matching the below regex filters will run
+               - master
       - release-version-with-changelog:
           context: binbashar-org-global-context
           filters:
@@ -419,5 +419,3 @@ workflows:
                - master
       # - sumologic/workflow-collector:
       #     context: binbashar-org-global-context
-          requires:
-            - release-version-with-changelog

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ jobs:
   #
   test-static-code-and-linting:
     machine: # https://circleci.com/docs/2.0/configuration-reference/#available-machine-images
-      image: ubuntu-2004:202107-01 # Ubuntu 16.04, Docker v19.03.12, Docker Compose v1.26.1
+      image: ubuntu-2204:edge
 
       # This job has been blocked because Docker Layer Caching is not available on your plan.
       # Should upgrade if necessary.
@@ -162,7 +162,7 @@ jobs:
   #
   release-version-with-changelog:
     machine:
-      image: ubuntu-2004:202107-01 # Ubuntu 16.04, Docker v19.03.12, Docker Compose v1.26.1
+      image: ubuntu-2204:edge
       docker_layer_caching: false
 
     environment:

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,8 @@
 SHELL         := /bin/bash
 MAKEFILE_PATH := ./Makefile
 MAKEFILES_DIR := ./@bin/makefiles
-MAKEFILES_VER := v0.1.33
+MAKEFILES_VER := v0.2.8
+PROJECT_SHORT := bb
 
 help:
 	@echo 'Available Commands:'
@@ -19,7 +20,6 @@ init-makefiles: ## initialize makefiles
 
 -include ${MAKEFILES_DIR}/circleci/circleci.mk
 -include ${MAKEFILES_DIR}/release-mgmt/release.mk
--include ${MAKEFILES_DIR}/terraform14/terraform14-root-context.mk
--include ${MAKEFILES_DIR}/terraform14/terraform14.mk
--include ${MAKEFILES_DIR}/terratest14/terratest14.mk
-
+-include ${MAKEFILES_DIR}/terraform1/terraform1-root-context.mk
+-include ${MAKEFILES_DIR}/terraform1/terraform1.mk
+-include ${MAKEFILES_DIR}/terratest1/terratest1.mk

--- a/Makefile
+++ b/Makefile
@@ -22,4 +22,3 @@ init-makefiles: ## initialize makefiles
 -include ${MAKEFILES_DIR}/release-mgmt/release.mk
 -include ${MAKEFILES_DIR}/terraform1/terraform1-root-context.mk
 -include ${MAKEFILES_DIR}/terraform1/terraform1.mk
--include ${MAKEFILES_DIR}/terratest1/terratest1.mk

--- a/README.md
+++ b/README.md
@@ -12,6 +12,12 @@ This mdule creates AWS Network firewall resources, which includes:
 * Network Firewall Policy
 * Network Firewall Stateless groups and rules
 * Network Firewall Stateful groups and rules
+* Use custom Suricata Rules
+* Use Managed Rules
+* Use “Strict, Drop Established” rule order
+* Use stateful rules instead of stateless rules
+* Use $HOME_NET
+
 
 ## Example
 **Deny domain access**
@@ -107,23 +113,29 @@ No modules.
 
 ## Inputs
 
+## Inputs
+
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_create_network_firewall"></a> [create\_network\_firewall](#input\_create\_network\_firewall) | Set to false if you just want to create the security policy, stateless and stateful rules | `bool` | `true` | no |
-| <a name="input_delete_protection"></a> [delete\_protection](#input\_delete\_protection) | A boolean flag indicating whether it is possible to delete the firewall. | `bool` | `false` | no |
+| <a name="input_delete_protection"></a> [delete\_protection](#input\_delete_protection) | A boolean flag indicating whether it is possible to delete the firewall. | `bool` | `false` | no |
 | <a name="input_description"></a> [description](#input\_description) | A friendly description of the firewall. | `string` | `null` | no |
 | <a name="input_enabled"></a> [enabled](#input\_enabled) | Change to false to avoid deploying AWS Network Firewall resources. | `bool` | `true` | no |
-| <a name="input_firewall_policy_change_protection"></a> [firewall\_policy\_change\_protection](#input\_firewall\_policy\_change\_protection) | A boolean flag indicating whether it is possible to change the associated firewall policy. | `bool` | `false` | no |
-| <a name="input_firewall_policy_name"></a> [firewall\_policy\_name](#input\_firewall\_policy\_name) | A friendly name of the firewall policy. | `string` | `null` | no |
+| <a name="input_firewall_policy_change_protection"></a> [firewall\_policy\_change\_protection](#input\_firewall\_policy\_change_protection) | A boolean flag indicating whether it is possible to change the associated firewall policy. | `bool` | `false` | no |
+| <a name="input_firewall_policy_name"></a> [firewall\_policy_name](#input\_firewall\_policy_name) | A friendly name of the firewall policy. | `string` | `null` | no |
 | <a name="input_name"></a> [name](#input\_name) | A friendly name of the firewall. | `string` | n/a | yes |
-| <a name="input_stateful_rule_groups"></a> [stateful\_rule\_groups](#input\_stateful\_rule\_groups) | Map of stateful rules groups. | `any` | `{}` | no |
-| <a name="input_stateless_default_actions"></a> [stateless\_default\_actions](#input\_stateless\_default\_actions) | Set of actions to take on a packet if it does not match any of the stateless rules in the policy. You must specify one of the standard actions including: `aws:drop`, `aws:pass`, or `aws:forward_to_sf`e. In addition, you can specify custom actions that are compatible with your standard action choice. If you want non-matching packets to be forwarded for stateful inspection, specify `aws:forward_to_sfe`. | `list(any)` | <pre>[<br>  "aws:drop"<br>]</pre> | no |
-| <a name="input_stateless_fragment_default_actions"></a> [stateless\_fragment\_default\_actions](#input\_stateless\_fragment\_default\_actions) | Set of actions to take on a fragmented packet if it does not match any of the stateless rules in the policy. You must specify one of the standard actions including: `aws:drop`, `aws:pass`, or `aws:forward_to_sf`e. In addition, you can specify custom actions that are compatible with your standard action choice. If you want non-matching packets to be forwarded for stateful inspection, specify `aws:forward_to_sfe`. | `list(any)` | <pre>[<br>  "aws:drop"<br>]</pre> | no |
-| <a name="input_stateless_rule_groups"></a> [stateless\_rule\_groups](#input\_stateless\_rule\_groups) | Map of stateless rules groups. | `any` | `{}` | no |
-| <a name="input_subnet_change_protection"></a> [subnet\_change\_protection](#input\_subnet\_change\_protection) | A boolean flag indicating whether it is possible to change the associated subnet(s). | `bool` | `false` | no |
+| <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | The unique identifier of the VPC where AWS Network Firewall should create the firewall. | `string` | n/a | yes |
 | <a name="input_subnet_mapping"></a> [subnet\_mapping](#input\_subnet\_mapping) | Subnets map. Each subnet must belong to a different Availability Zone in the VPC. AWS Network Firewall creates a firewall endpoint in each subnet. | `map(any)` | n/a | yes |
-| <a name="input_tags"></a> [tags](#input\_tags) | Map of resource tags to associate with the resource. If configured with a provider default\_tags configuration block present, tags with matching keys will overwrite those defined at the provider-level. | `map(string)` | `{}` | no |
-| <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | The unique identifier of the VPC where AWS Network Firewall should create the firewall | `string` | n/a | yes |
+| <a name="input_stateless_default_actions"></a> [stateless\_default\_actions](#input\_stateless\_default\_actions) | Set of actions to take on a packet if it does not match any of the stateless rules in the policy. You must specify one of the standard actions including: `aws:drop`, `aws:pass`, or `aws:forward_to_sf`. | `list(any)` | `["aws:drop"]` | no |
+| <a name="input_stateless_fragment_default_actions"></a> [stateless\_fragment\_default_actions](#input\_stateless\_fragment\_default_actions) | Set of actions to take on a fragmented packet if it does not match any of the stateless rules in the policy. | `list(any)` | `["aws:drop"]` | no |
+| <a name="input_stateless_rule_groups"></a> [stateless\_rule\_groups](#input\_stateless\_rule\_groups) | Map of stateless rules groups, including custom actions. | `any` | `{}` | no |
+| <a name="input_stateful_rule_groups"></a> [stateful\_rule\_groups](#input\_stateful\_rule\_groups) | Map of stateful rules groups, including Suricata and AWS Managed Rules. | `any` | `{}` | no |
+| <a name="input_stateful_suricata_rule_groups"></a> [stateful\_suricata_rule_groups](#input\_stateful\_suricata\_rule\_groups) | Map of custom Suricata rules for stateful inspection. | `any` | `{}` | no |
+| <a name="input_managed_rule_groups"></a> [managed\_rule\_groups](#input\_managed\_rule\_groups) | Map of AWS Managed Rule Groups for stateful inspection. | `any` | `{}` | no |
+| <a name="input_rule_order"></a> [rule\_order](#input\_rule\_order) | The order in which stateless rules are evaluated: `STRICT_ORDER` or `DEFAULT_ACTION_ORDER`. | `string` | `"DEFAULT_ACTION_ORDER"` | no |
+| <a name="input_stream_exception_policy"></a> [stream\_exception\_policy](#input\_stream_exception\_policy) | Policy for handling stream exceptions: `DROP`, `CONTINUE`, or `REJECT`. | `string` | `"DROP"` | no |
+| <a name="input_home_net_cidr"></a> [home\_net\_cidr](#input\_home\_net\_cidr) | CIDR block to define the home network for the firewall rules. | `string` | n/a | yes |
+
 
 ## Outputs
 
@@ -131,8 +143,11 @@ No modules.
 |------|-------------|
 | <a name="output_arn"></a> [arn](#output\_arn) | The Amazon Resource Name (ARN) that identifies the firewall. |
 | <a name="output_id"></a> [id](#output\_id) | The ID that identifies the firewall. |
-| <a name="output_network_firewall_policy"></a> [network\_firewall\_policy](#output\_network\_firewall\_policy) | The Firewall Network policy created |
-| <a name="output_network_firewall_stateful_group"></a> [network\_firewall\_stateful\_group](#output\_network\_firewall\_stateful\_group) | Map of stateful group rules |
-| <a name="output_network_firewall_stateless_group"></a> [network\_firewall\_stateless\_group](#output\_network\_firewall\_stateless\_group) | Map of stateless group rules |
+| <a name="output_network_firewall_policy"></a> [network\_firewall\_policy](#output\_network\_firewall\_policy) | The Firewall Network policy created. |
+| <a name="output_network_firewall_stateful_group"></a> [network\_firewall\_stateful\_group](#output\_network\_firewall\_stateful\_group) | Map of stateful group rules. |
+| <a name="output_network_firewall_stateless_group"></a> [network\_firewall\_stateless\_group](#output\_network\_firewall\_stateless\_group) | Map of stateless group rules. |
 | <a name="output_network_firewall_status"></a> [network\_firewall\_status](#output\_network\_firewall\_status) | Nested list of information about the current status of the firewall. |
+| <a name="output_network_firewall_suricata_rule_groups"></a> [network\_firewall\_suricata\_rule\_groups](#output\_network\_firewall\_suricata\_rule\_groups) | Map of Suricata rule groups for stateful inspection. |
+| <a name="output_network_firewall_managed_rule_groups"></a> [network\_firewall\_managed\_rule\_groups](#output\_network\_firewall\_managed\_rule\_groups) | Map of AWS Managed Rule Groups for stateful inspection. |
+
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/complete/locals.tf
+++ b/examples/complete/locals.tf
@@ -1,4 +1,102 @@
 locals {
+  
+  home_net_cidr = ["10.10.0.0/16"]
+  
+  # Network Firewall
+  managed_rule_groups = [
+    {
+      name         = "BotNetCommandAndControlDomainsStrictOrder"
+      arn          = "arn:aws:network-firewall:us-east-1:aws-managed:stateful-rulegroup/BotNetCommandAndControlDomainsStrictOrder"
+      priority     = 10
+    },
+    {
+      name         = "AbusedLegitBotNetCommandAndControlDomainsStrictOrder"
+      arn          = "arn:aws:network-firewall:us-east-1:aws-managed:stateful-rulegroup/AbusedLegitBotNetCommandAndControlDomainsStrictOrder"
+      priority     = 11
+    },
+    {
+      name         = "MalwareDomainsStrictOrder"
+      arn          = "arn:aws:network-firewall:us-east-1:aws-managed:stateful-rulegroup/MalwareDomainsStrictOrder"
+      priority     = 12
+    },
+    {
+      name         = "AbusedLegitMalwareDomainsStrictOrder"
+      arn          = "arn:aws:network-firewall:us-east-1:aws-managed:stateful-rulegroup/AbusedLegitMalwareDomainsStrictOrder"
+      priority     = 13
+    },
+    {
+      name         = "ThreatSignaturesDoSStrictOrder"
+      arn          = "arn:aws:network-firewall:us-east-1:aws-managed:stateful-rulegroup/ThreatSignaturesDoSStrictOrder"
+      action_mode  = "DROP_TO_ALERT"
+      priority     = 14
+    },
+    {
+      name         = "ThreatSignaturesSuspectStrictOrder"
+      arn          = "arn:aws:network-firewall:us-east-1:aws-managed:stateful-rulegroup/ThreatSignaturesSuspectStrictOrder"
+      action_mode  = "DROP_TO_ALERT"
+      priority     = 15
+    },
+    {
+      name         = "ThreatSignaturesExploitsStrictOrder"
+      arn          = "arn:aws:network-firewall:us-east-1:aws-managed:stateful-rulegroup/ThreatSignaturesExploitsStrictOrder"
+      action_mode  = "DROP_TO_ALERT"
+      priority     = 16
+    },
+    {
+      name         = "ThreatSignaturesScannersStrictOrder"
+      arn          = "arn:aws:network-firewall:us-east-1:aws-managed:stateful-rulegroup/ThreatSignaturesScannersStrictOrder"
+      action_mode  = "DROP_TO_ALERT"
+      priority     = 17
+    },
+    {
+      name         = "ThreatSignaturesIOCStrictOrder"
+      arn          = "arn:aws:network-firewall:us-east-1:aws-managed:stateful-rulegroup/ThreatSignaturesIOCStrictOrder"
+      action_mode  = "DROP_TO_ALERT"
+      priority     = 18
+    },
+    {
+      name         = "ThreatSignaturesWebAttacksStrictOrder"
+      arn          = "arn:aws:network-firewall:us-east-1:aws-managed:stateful-rulegroup/ThreatSignaturesWebAttacksStrictOrder"
+      action_mode  = "DROP_TO_ALERT"
+      priority     = 19
+    }
+  ]
+
+  suricata_rules = {
+    stateful-group = {
+      description  = "Suricata rule group"
+      capacity     = 100
+      priority     = 50
+      rules_string = <<EOF
+         # Silently allow TCP 3-way handshake to be setup by $HOME_NET clients
+        pass tcp $HOME_NET any -> !$HOME_NET any (flow:not_established, to_server; msg:"pass rules do not alert/log"; sid:9918156;)
+        pass tcp !$HOME_NET any -> !$HOME_NET any (flow:not_established, to_client; msg:"pass rules do not alert/log"; sid:9918199;)
+        pass tcp $HOME_NET any -> $HOME_NET 443 (flow:to_server; msg:"Allow HTTPS traffic between internal VPCs"; sid:1000010; rev:1;)
+        pass tcp $HOME_NET any -> $HOME_NET 80 (flow:to_server; msg:"Allow HTTP traffic between internal VPCs"; sid:1000011; rev:1;)
+        pass tcp $HOME_NET any -> $HOME_NET 22 (flow:to_server; msg:"Allow SSH traffic between internal VPCs"; sid:1000012; rev:1;)
+        pass tcp $HOME_NET any -> $HOME_NET 21 (flow:to_server; msg:"Allow FTP control traffic between internal VPCs"; sid:1000013; rev:1;)
+        pass tcp $HOME_NET any -> $HOME_NET 20 (flow:to_server; msg:"Allow FTP data traffic between internal VPCs"; sid:1000014; rev:1;)
+        pass udp $HOME_NET any -> $HOME_NET 53 (flow:to_server; msg:"Allow DNS traffic between internal VPCs"; sid:1000016; rev:1;)
+        pass udp $HOME_NET 53 -> $HOME_NET any (flow:to_client; msg:"Allow inbound DNS traffic to internal networks"; sid:1000023; rev:1;)
+        alert tcp $HOME_NET any -> $HOME_NET any (flow:to_server, established; msg:"Reject unapproved TCP traffic between internal VPCs"; sid:1000024; rev:1;)
+        reject tcp $HOME_NET any -> $HOME_NET any (flow:to_server, established; msg:"Reject unapproved TCP traffic between internal VPCs"; sid:1000017; rev:1;)
+        drop udp $HOME_NET any -> $HOME_NET any (flow:to_server; msg:"Drop unapproved UDP traffic between internal VPCs"; sid:1000018; rev:1;)
+        pass tcp $HOME_NET any -> !$HOME_NET 443 (flow:to_server; msg:"Allow outbound HTTPS traffic to external networks"; sid:1000003; rev:1;)
+        pass tcp $HOME_NET any -> !$HOME_NET 80 (flow:to_server; msg:"Allow outbound HTTP traffic to external networks"; sid:1000004; rev:1;)
+        pass tcp $HOME_NET any -> !$HOME_NET 22 (flow:to_server; msg:"Allow outbound SSH traffic to external networks"; sid:1000005; rev:1;)
+        pass tcp $HOME_NET any -> !$HOME_NET 21 (flow:to_server; msg:"Allow outbound FTP control traffic"; sid:1000006; rev:1;)
+        pass tcp $HOME_NET any -> !$HOME_NET 20 (flow:to_server; msg:"Allow outbound FTP data traffic"; sid:1000007; rev:1;)
+        pass udp $HOME_NET any -> !$HOME_NET 123 (flow:to_server; msg:"Allow outbound NTP traffic to external networks"; sid:1000008; rev:1;)
+        pass udp !$HOME_NET 123 -> $HOME_NET any (flow:to_client; msg:"Allow inbound NTP traffic to internal networks"; sid:1000021; rev:1;)
+        pass udp $HOME_NET any -> !$HOME_NET 53 (flow:to_server; msg:"Allow outbound DNS traffic to external networks"; sid:1000009; rev:1;)
+        pass udp !$HOME_NET 53 -> $HOME_NET any (flow:to_client; msg:"Allow inbound DNS traffic to internal networks"; sid:1000022; rev:1;)
+        alert tcp $HOME_NET any -> !$HOME_NET any (flow:to_server, established; msg:"Reject unapproved TCP traffic to external networks"; sid:9822312;)
+        reject tcp $HOME_NET any -> !$HOME_NET any (flow:to_server, established; msg:"Reject unapproved TCP traffic to external networks"; sid:9822311;)
+        drop udp $HOME_NET any -> !$HOME_NET any (flow:to_server; msg:"Drop unapproved UDP traffic to external networks"; sid:82319824;)
+      EOF
+    }
+  }
+  
   tags = {
     Terraform   = "true"
     Environment = var.environment

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -29,6 +29,12 @@ module "firewall" {
   rule_order = "STRICT_ORDER"
   stream_exception_policy = "REJECT"
 
+  enable_firewall_logs        = true
+  log_destination_type        = "CLOUDWATCHLOGS"
+  cloudwatch_log_group_name   = "/aws/network-firewall/"
+  log_type                    = ["FLOW", "ALERT"]
+  log_retention_in_days       = 365
+
   # Stateless rule groups
   stateless_rule_groups = {
     stateless-group-example-1 = {

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -17,6 +17,18 @@ module "firewall" {
   vpc_id         = data.terraform_remote_state.inspection_vpc.outputs.vpc_id
   subnet_mapping = data.terraform_remote_state.inspection_vpc.outputs.inspection_subnets
 
+  stateless_default_actions          = ["aws:forward_to_sfe"]
+  stateless_fragment_default_actions = ["aws:drop"]
+
+  home_net_cidr = local.home_net_cidr
+
+  stateful_suricata_rule_groups = local.suricata_rules
+
+  managed_rule_groups = local.managed_rule_groups
+
+  rule_order = "STRICT_ORDER"
+  stream_exception_policy = "REJECT"
+
   # Stateless rule groups
   stateless_rule_groups = {
     stateless-group-example-1 = {

--- a/main.tf
+++ b/main.tf
@@ -32,6 +32,7 @@ resource "aws_networkfirewall_firewall_policy" "policy" {
   firewall_policy {
     stateless_default_actions          = var.stateless_default_actions
     stateless_fragment_default_actions = var.stateless_fragment_default_actions
+    
 
     # Stateless rule group reference
     dynamic "stateless_rule_group_reference" {
@@ -47,6 +48,46 @@ resource "aws_networkfirewall_firewall_policy" "policy" {
       for_each = var.stateful_rule_groups
       content {
         resource_arn = aws_networkfirewall_rule_group.stateful_rule_group[stateful_rule_group_reference.key].arn
+      }
+    }
+
+    # Stateful rule group reference
+    dynamic "stateful_rule_group_reference" {
+      for_each = var.stateful_suricata_rule_groups
+      content {
+        priority = lookup(stateful_rule_group_reference.value, "priority")
+        resource_arn = aws_networkfirewall_rule_group.stateful_suricata_rule_group[stateful_rule_group_reference.key].arn
+      }
+    }
+
+    # Managed Rule Group reference (grupo separado)
+    dynamic "stateful_rule_group_reference" {
+      for_each = var.managed_rule_groups
+      content {
+        priority = lookup(stateful_rule_group_reference.value, "priority")
+        resource_arn = lookup(stateful_rule_group_reference.value, "arn")
+        dynamic "override" {
+            for_each = lookup(stateful_rule_group_reference.value, "action_mode", null) != null ? [1] : []
+            content {
+              action = lookup(stateful_rule_group_reference.value, "action_mode")
+          }
+        }
+      }
+    }
+   
+    stateful_engine_options {
+      rule_order = var.rule_order
+      stream_exception_policy = var.stream_exception_policy
+    }
+   
+   stateful_default_actions = var.rule_order == "STRICT_ORDER" ? ["aws:drop_established", "aws:alert_established"] : []  
+    
+    policy_variables {
+      rule_variables {
+        key = "HOME_NET"
+        ip_set {
+          definition = var.home_net_cidr
+        }
       }
     }
   }
@@ -222,8 +263,349 @@ resource "aws_networkfirewall_rule_group" "stateful_rule_group" {
         }
       }
     }
+    
+  
+  }
+  tags = var.tags
+}
+
+resource "aws_networkfirewall_rule_group" "stateful_suricata_rule_group" {
+  for_each = var.stateful_suricata_rule_groups
+
+  name        = each.key
+  description = lookup(each.value, "description", "Suricata rule group")
+  capacity    = lookup(each.value, "capacity", 200)
+  type        = "STATEFUL"
+
+  
+  rule_group {
+    stateful_rule_options {
+      rule_order = lookup(each.value, "rule_order", "STRICT_ORDER")
+    }
+    rules_source {
+      rules_string = lookup(each.value, "rules_string", null)
+    }
+    rule_variables {
+      ip_sets {
+        key = "HOME_NET"
+        ip_set {
+          definition = var.home_net_cidr
+        }
+      }
+      ip_sets {
+        key = "EXTERNAL_NET"
+        ip_set {
+          definition = var.external_net_cidr
+        }
+      }
+    }
   }
 
   tags = var.tags
 }
 
+# Firewall
+resource "aws_networkfirewall_firewall" "firewall" {
+
+  count = var.enabled && var.create_network_firewall ? 1 : 0
+
+  name                              = var.name
+  description                       = var.description
+  delete_protection                 = var.delete_protection
+  firewall_policy_change_protection = var.firewall_policy_change_protection
+  subnet_change_protection          = var.subnet_change_protection
+  firewall_policy_arn               = aws_networkfirewall_firewall_policy.policy[0].arn
+  vpc_id                            = var.vpc_id
+
+  # Subnets mapping
+  dynamic "subnet_mapping" {
+    for_each = var.subnet_mapping
+    content {
+      subnet_id = subnet_mapping.value
+    }
+  }
+
+  tags = var.tags
+}
+
+# Policy
+resource "aws_networkfirewall_firewall_policy" "policy" {
+
+  count = var.enabled ? 1 : 0
+
+  name = var.firewall_policy_name == null ? "${var.name}-policy" : var.firewall_policy_name
+
+  firewall_policy {
+    stateless_default_actions          = var.stateless_default_actions
+    stateless_fragment_default_actions = var.stateless_fragment_default_actions
+    
+
+    # Stateless rule group reference
+    dynamic "stateless_rule_group_reference" {
+      for_each = var.stateless_rule_groups
+      content {
+        priority     = lookup(stateless_rule_group_reference.value, "priority")
+        resource_arn = aws_networkfirewall_rule_group.stateless_rule_group[stateless_rule_group_reference.key].arn
+      }
+    }
+
+    # Stateful rule group reference
+    dynamic "stateful_rule_group_reference" {
+      for_each = var.stateful_rule_groups
+      content {
+        resource_arn = aws_networkfirewall_rule_group.stateful_rule_group[stateful_rule_group_reference.key].arn
+      }
+    }
+
+    # Stateful rule group reference
+    dynamic "stateful_rule_group_reference" {
+      for_each = var.stateful_suricata_rule_groups
+      content {
+        priority = lookup(stateful_rule_group_reference.value, "priority")
+        resource_arn = aws_networkfirewall_rule_group.stateful_suricata_rule_group[stateful_rule_group_reference.key].arn
+      }
+    }
+
+    # Managed Rule Group reference (grupo separado)
+    dynamic "stateful_rule_group_reference" {
+      for_each = var.managed_rule_groups
+      content {
+        priority = lookup(stateful_rule_group_reference.value, "priority")
+        resource_arn = lookup(stateful_rule_group_reference.value, "arn")
+        dynamic "override" {
+            for_each = lookup(stateful_rule_group_reference.value, "action_mode", null) != null ? [1] : []
+            content {
+              action = lookup(stateful_rule_group_reference.value, "action_mode")
+          }
+        }
+      }
+    }
+   
+    stateful_engine_options {
+      rule_order = var.rule_order
+      stream_exception_policy = var.stream_exception_policy
+    }
+   
+   stateful_default_actions = var.rule_order == "STRICT_ORDER" ? ["aws:drop_established", "aws:alert_established"] : []  
+    
+    policy_variables {
+      rule_variables {
+        key = "HOME_NET"
+        ip_set {
+          definition = var.home_net_cidr
+        }
+      }
+    }
+  }
+
+  tags = var.tags
+
+  depends_on = [aws_networkfirewall_rule_group.stateless_rule_group]
+}
+
+# Stateless rule groups
+resource "aws_networkfirewall_rule_group" "stateless_rule_group" {
+
+  for_each = {
+    for k, v in var.stateless_rule_groups :
+    k => v if var.enabled
+  }
+
+  name        = each.key
+  description = lookup(each.value, "description")
+  capacity    = lookup(each.value, "capacity", 100)
+  type        = "STATELESS"
+
+  rule_group {
+    rules_source {
+      stateless_rules_and_custom_actions {
+        # Customs actions
+        dynamic "custom_action" {
+          for_each = lookup(each.value, "custom_actions", {})
+          content {
+            action_name = custom_action.key
+            action_definition {
+              publish_metric_action {
+                dimension {
+                  value = custom_action.value
+                }
+              }
+            }
+          }
+        }
+
+        # Stateless rules
+        dynamic "stateless_rule" {
+          for_each = lookup(each.value, "rules", [])
+          content {
+            priority = lookup(stateless_rule.value, "priority")
+            rule_definition {
+              actions = lookup(stateless_rule.value, "actions")
+              match_attributes {
+                protocols = lookup(stateless_rule.value, "protocols", null)
+                # Source
+                dynamic "source" {
+                  for_each = lookup(stateless_rule.value, "source", null) == null ? [] : [lookup(stateless_rule.value, "source")]
+                  content {
+                    address_definition = lookup(source.value, "address")
+                  }
+                }
+                dynamic "source_port" {
+                  for_each = lookup(stateless_rule.value, "source_port", null) == null ? [] : [lookup(stateless_rule.value, "source_port")]
+                  content {
+                    from_port = lookup(source_port.value, "from_port", null)
+                    to_port   = lookup(source_port.value, "to_port", null)
+                  }
+                }
+                # Destination
+                dynamic "destination" {
+                  for_each = lookup(stateless_rule.value, "destination", null) == null ? [] : [lookup(stateless_rule.value, "destination")]
+                  content {
+                    address_definition = lookup(destination.value, "address")
+                  }
+                }
+                dynamic "destination_port" {
+                  for_each = lookup(stateless_rule.value, "destination_port", null) == null ? [] : [lookup(stateless_rule.value, "destination_port")]
+                  content {
+                    from_port = lookup(destination_port.value, "from_port", null)
+                    to_port   = lookup(destination_port.value, "to_port", null)
+                  }
+                }
+                # TCP flag
+                dynamic "tcp_flag" {
+                  for_each = lookup(stateless_rule.value, "tcp_flag", null) == null ? [] : [lookup(stateless_rule.value, "tcp_flag")]
+                  content {
+                    flags = lookup(tcp_flag.value, "flags", null)
+                    masks = lookup(tcp_flag.value, "masks", null)
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  tags = var.tags
+}
+
+# Stateful rule groups
+resource "aws_networkfirewall_rule_group" "stateful_rule_group" {
+
+  for_each = {
+    for k, v in var.stateful_rule_groups :
+    k => v if var.enabled
+  }
+
+  name        = each.key
+  description = lookup(each.value, "description")
+  capacity    = lookup(each.value, "capacity", 100)
+  type        = "STATEFUL"
+  rule_group {
+    # rule variables
+    dynamic "rule_variables" {
+      for_each = lookup(each.value, "rule_variables", null) == null ? [] : [lookup(each.value, "rule_variables", {})]
+      content {
+        # IP Sets
+        dynamic "ip_sets" {
+          for_each = lookup(rule_variables.value, "ip_sets", null) == null ? {} : lookup(rule_variables.value, "ip_sets")
+          content {
+            key = ip_sets.key
+            ip_set {
+              definition = ip_sets.value
+            }
+          }
+        }
+        # Port Sets
+        dynamic "port_sets" {
+          for_each = lookup(rule_variables.value, "port_sets", null) == null ? {} : lookup(rule_variables.value, "port_sets")
+          content {
+            key = port_sets.key
+            port_set {
+              definition = port_sets.value
+            }
+          }
+        }
+      }
+    }
+    rules_source {
+      # Rules source lists
+      dynamic "rules_source_list" {
+        for_each = lookup(each.value, "rules_source_list", null) == null ? [] : [lookup(each.value, "rules_source_list")]
+        content {
+          generated_rules_type = lookup(rules_source_list.value, "generated_rules_type")
+          target_types         = lookup(rules_source_list.value, "target_types")
+          targets              = lookup(rules_source_list.value, "targets")
+        }
+      }
+
+      # Rules strings
+      rules_string = lookup(each.value, "rules_string", null)
+
+      # Stateful rules
+      dynamic "stateful_rule" {
+        for_each = lookup(each.value, "stateful_rule", null) == null ? [] : [lookup(each.value, "stateful_rule")]
+        content {
+          action = lookup(stateful_rule.value, "action")
+          dynamic "header" {
+            for_each = [lookup(stateful_rule.value, "header", {})]
+            content {
+              destination      = lookup(header.value, "destination")
+              destination_port = lookup(header.value, "destination_port")
+              direction        = lookup(header.value, "direction")
+              protocol         = lookup(header.value, "protocol")
+              source           = lookup(header.value, "source")
+              source_port      = lookup(header.value, "source_port")
+            }
+          }
+          dynamic "rule_option" {
+            for_each = [lookup(stateful_rule.value, "rule_option", {})]
+            content {
+              keyword  = lookup(rule_option.value, "keyword")
+              settings = lookup(rule_option.value, "settings", [])
+            }
+          }
+        }
+      }
+    }
+    
+  
+  }
+  tags = var.tags
+}
+
+resource "aws_networkfirewall_rule_group" "stateful_suricata_rule_group" {
+  for_each = var.stateful_suricata_rule_groups
+
+  name        = each.key
+  description = lookup(each.value, "description", "Suricata rule group")
+  capacity    = lookup(each.value, "capacity", 200)
+  type        = "STATEFUL"
+
+  
+  rule_group {
+    stateful_rule_options {
+      rule_order = lookup(each.value, "rule_order", "STRICT_ORDER")
+    }
+    rules_source {
+      rules_string = lookup(each.value, "rules_string", null)
+    }
+    rule_variables {
+      ip_sets {
+        key = "HOME_NET"
+        ip_set {
+          definition = var.home_net_cidr
+        }
+      }
+      ip_sets {
+        key = "EXTERNAL_NET"
+        ip_set {
+          definition = var.external_net_cidr
+        }
+      }
+    }
+  }
+
+  tags = var.tags
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -28,3 +28,8 @@ output "network_firewall_stateful_group" {
   description = "Map of stateful group rules"
   value       = var.enabled ? aws_networkfirewall_rule_group.stateful_rule_group : null
 }
+
+output "network_firewall_suricata_rule_groups" {
+  description = "Map of Suricata rule groups"
+  value       = var.enabled ? aws_networkfirewall_rule_group.stateful_suricata_rule_group : null
+}

--- a/variables.tf
+++ b/variables.tf
@@ -135,3 +135,45 @@ variable "stream_exception_policy" {
   type        = string
   default     = "DROP"
 }
+
+variable "enable_firewall_logs" {
+  type    = bool
+  default = false
+  description = "Enable logging for the firewall"
+}
+
+variable "log_destination_type" {
+  type    = string
+  default = "CLOUDWATCHLOGS"
+  description = "Log destination type. Options: CLOUDWATCHLOGS, S3, KinesisDataFirehose"
+}
+
+variable "log_type" {
+  type    = list(string)
+  default = ["FLOW", "ALERT"]
+  description = "Log types to enable. Options: FLOW, ALERT"
+}
+
+variable "cloudwatch_log_group_name" {
+  type    = string
+  default = null
+  description = "CloudWatch log group name"
+}
+
+variable "s3_bucket_name" {
+  type    = string
+  default = null
+  description = "S3 bucket name"
+}
+
+variable "kinesis_stream_arn" {
+  type    = string
+  default = null
+  description = "Amazon Resource Name (ARN) of the Kinesis Data Firehose stream"
+}
+
+variable "log_retention_in_days" {
+  type    = number
+  default = 90
+  description = "The number of days to retain log events in the log group"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -66,7 +66,7 @@ variable "stateless_rule_groups" {
 variable "stateless_default_actions" {
   description = "Set of actions to take on a packet if it does not match any of the stateless rules in the policy. You must specify one of the standard actions including: `aws:drop`, `aws:pass`, or `aws:forward_to_sf`e. In addition, you can specify custom actions that are compatible with your standard action choice. If you want non-matching packets to be forwarded for stateful inspection, specify `aws:forward_to_sfe`."
   type        = list(any)
-  default     = ["aws:drop"]
+  default     = ["aws:aws:forward_to_sfe"]
 }
 
 variable "stateless_fragment_default_actions" {
@@ -82,9 +82,56 @@ variable "stateful_rule_groups" {
   default     = {}
 }
 
+# Stateful Suricata rules
+variable "stateful_suricata_rule_groups" {
+  description = "Optional stateful Suricata rule groups"
+  type = map(object({
+    description  = string
+    capacity     = number
+    rules_string = string
+    priority     = number
+  }))
+  default = {}
+}
+
 # Tags
 variable "tags" {
   description = "Map of resource tags to associate with the resource. If configured with a provider default_tags configuration block present, tags with matching keys will overwrite those defined at the provider-level."
   type        = map(string)
   default     = {}
+}
+
+variable "managed_rule_groups" {
+  description = "List of managed rule groups with ARNs, priorities, and action modes"
+  type = list(object({
+    name        = string
+    arn         = string
+    action_mode = optional(string)
+    priority    = string
+  }))
+  default = []
+}
+
+variable "rule_order" {
+  description = "Define the rule evaluation order for stateful rule groups. Options: STRICT_ORDER, DEFAULT_ACTION_ORDER."
+  type        = string
+  default     = "DEFAULT_ACTION_ORDER"
+}
+
+variable "home_net_cidr" {
+  description = "List of CIDR blocks for the internal network (HOME_NET)"
+  type        = list(string)
+  default     = []
+}
+
+variable "external_net_cidr" {
+  description = "List of CIDR blocks for the externla network (EXTERNAL_NET)"
+  type        = list(string)
+  default     = []
+}
+
+variable "stream_exception_policy" {
+  description = "Define the action to take on a packet that does not match any stateful rule group. Options: DROP, ALERT."
+  type        = string
+  default     = "DROP"
 }


### PR DESCRIPTION
What

- Add support for AWS Managed Rule Groups and custom Suricata rules.
- Add parameters to configure rule order and stream exception policies.
- Update stateless_rule_groups to support custom actions and multiple rule configurations.
- Enhance the module to handle advanced stateful rule groups, including the use of rule variables like IP sets and port sets.

Why

- This change allows users to leverage existing managed rules and define their own Suricata rules for stateful inspection.
- Added flexibility to control rule evaluation order and how exceptions in streams are handled, providing more control over firewall behavior.

References

https://aws.github.io/aws-security-services-best-practices/guides/network-firewall/

